### PR TITLE
introduce ParameterMissingError

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   koaMiddleware: require('./middlewares/koa'),
   expressMiddleware: require('./middlewares/express'),
-  Parameters: require('./parameters')
+  Parameters: require('./parameters'),
+  ParameterMissingError: require('./parameter-missing-error')
 }

--- a/lib/parameter-missing-error.js
+++ b/lib/parameter-missing-error.js
@@ -1,0 +1,10 @@
+var util = require('util')
+
+function ParameterMissingError (message) {
+  Error.captureStackTrace(this, this.constructor)
+  this.name = this.constructor.name
+  this.message = message
+}
+
+util.inherits(ParameterMissingError, Error)
+module.exports = ParameterMissingError

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -9,6 +9,7 @@ require('es6-object-assign').polyfill()
  */
 
 var _ = require('lodash')
+var ParameterMissingError = require('./parameter-missing-error')
 
 /**
  * Constants.
@@ -103,7 +104,7 @@ Object.assign(Parameters.prototype, {
 
   require: function (key) {
     var param = Parameters.clone(this._fetch(key))
-    if (!param) throw new Error('param `' + key + '` required')
+    if (!param) throw new ParameterMissingError('param `' + key + '` required')
     if (!(param instanceof Parameters)) throw new Error('param `' + key + '` is not a Parameters instance')
     return param
   },

--- a/spec/parameter-missing-error.js
+++ b/spec/parameter-missing-error.js
@@ -1,0 +1,15 @@
+/* global describe, it */
+var ParameterMissingError = require('..').ParameterMissingError
+
+describe('ParameterMissingError', function () {
+  it('should be instance of Error', function () {
+    var subject = new ParameterMissingError()
+    subject.should.be.a.instanceOf(Error)
+  })
+
+  it('should assing a message passed in constructor', function () {
+    var message = 'lorem ipsum'
+    var subject = new ParameterMissingError(message)
+    subject.message.should.eql(message)
+  })
+})

--- a/spec/parameters.js
+++ b/spec/parameters.js
@@ -3,6 +3,7 @@ var should = require('should')
 var sinon = require('sinon')
 
 var Parameters = require('..').Parameters
+var ParameterMissingError = require('..').ParameterMissingError
 var PRIMITIVE_TYPES = [Boolean, Number, String, function Null () {
   this.valueOf = function () { return null }
 }]
@@ -107,7 +108,27 @@ describe('Parameters', function () {
 
   })
 
-  describe('instance methods', function () {})
+  describe('instance methods', function () {
+    describe('require', function () {
+      var params
+      beforeEach(function () {
+        params = new Parameters({ requiredKey: {} })
+      })
+      describe('when required key passed', function () {
+        it('should return instance of parameters', function () {
+          params.require('requiredKey').should.be.a.instanceOf(Parameters)
+        })
+      })
+      describe('when required key not passed', function () {
+        it('should throw instance of ParameterMissingError with error message', function () {
+          var requireFunction = function () {
+            params.require('missingKey')
+          }
+          should.throws(requireFunction, ParameterMissingError, 'param `missingKey` required')
+        })
+      })
+    })
+  })
 
   describe('operations', function () {
 


### PR DESCRIPTION
Maybe not ideal implementation of Error class inheritance.
What i actually want to have
```js
try {
  params.require('missingKey')
}
catch(err) {
  err instanceof ParameterMissingError // -> true
  err instanceof Error // -> true
}
```