### PR TITLE
Update to koa v2.x middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.12"
-  - "4"
-  - "6"
+  - "8"
 sudo: false
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://travis-ci.org/ssowonny/strong-params.svg?branch=master)&nbsp;[![NPM version](https://badge.fury.io/js/strong-params.svg)](http://badge.fury.io/js/strong-params)
 
-Rails-style implementation of strong parameters. It supports [Express](http://expressjs.com/), [Koa](https://github.com/koajs/koa) and also can be used as standalone. The middleware adds the `parameters` object to the [Express request](http://expressjs.com/4x/api.html#req) (or `this.params` for [Koa context](http://koajs.com/#context)) which returns an object, built from `query string`, `request body` and `route params` data. The returned object has some useful methods allows for data `requiring` and `filtering`.
+Rails-style implementation of strong parameters. It supports [Express](http://expressjs.com/), [Koa](https://github.com/koajs/koa) and also can be used as standalone. The middleware adds the `parameters` object to the [Express request](http://expressjs.com/4x/api.html#req) (or `ctx.parameters` for [Koa context](http://koajs.com/#context)) which returns an object, built from `query string`, `request body` and `route params` data. The returned object has some useful methods allows for data `requiring` and `filtering`.
 
 ## Notice
 
@@ -31,7 +31,7 @@ app.use(params.expressMiddleware())
 ```js
 var koa = require('koa')
 var params = require('strong-params')
-var app = koa()
+var app = new koa()
 app.use(params.koaMiddleware())
 ```
 
@@ -50,8 +50,8 @@ app.use(function (req, res, next) {
 ##### Koa
 
 ```js
-app.use(function *() {
-  var params = this.params
+app.use(function (ctx, next) {
+  var params = ctx.parameters
 })
 ```
 

--- a/lib/middlewares/express.js
+++ b/lib/middlewares/express.js
@@ -10,7 +10,6 @@ var Parameters = require('../parameters')
 
 module.exports = function () {
   return function (req, res, next) {
-
     /**
      * Params data.
      */
@@ -63,4 +62,3 @@ module.exports = function () {
     next()
   }
 }
-

--- a/lib/middlewares/koa.js
+++ b/lib/middlewares/koa.js
@@ -21,7 +21,7 @@ module.exports = function () {
      * Params `getter` and `setter`.
      */
 
-    Object.defineProperty(ctx, 'params', {
+    Object.defineProperty(ctx, 'parameters', {
 
       /**
        * Returns an extended data object of merged context params.
@@ -51,10 +51,11 @@ module.exports = function () {
      *
      * NOTE: Use the `koa-qs` module to enable nested query string objects. To
      * enable body params, which are usually received over `post` or `put`
-     * method, use `koa-bodyparser` middleware.
+     * method, use `koa-bodyparser` middleware. To enable route params,
+     * use `koa-router` middleware.
      */
 
-    ctx.params = _.merge({}, ctx.request.body, ctx.query)
+    ctx.parameters = _.merge({}, ctx.request.body, ctx.query, ctx.params)
 
     /*
      * Next middleware.

--- a/lib/middlewares/koa.js
+++ b/lib/middlewares/koa.js
@@ -4,12 +4,12 @@ var Parameters = require('../parameters')
 /**
  * Koa middleware for strong params.
  *
- * @return {generator}
+ * @return {Function}
  * @api public
  */
 
 module.exports = function () {
-  return function *(next) {
+  return function (ctx, next) {
 
     /**
      * Params data.
@@ -21,7 +21,7 @@ module.exports = function () {
      * Params `getter` and `setter`.
      */
 
-    Object.defineProperty(this, 'params', {
+    Object.defineProperty(ctx, 'params', {
 
       /**
        * Returns an extended data object of merged context params.
@@ -54,12 +54,12 @@ module.exports = function () {
      * method, use `koa-bodyparser` middleware.
      */
 
-    this.params = _.merge({}, this.request.body, this.query)
+    ctx.params = _.merge({}, ctx.request.body, ctx.query)
 
     /*
      * Next middleware.
      */
 
-    yield next
+    return next()
   }
 }

--- a/lib/middlewares/koa.js
+++ b/lib/middlewares/koa.js
@@ -10,7 +10,6 @@ var Parameters = require('../parameters')
 
 module.exports = function () {
   return function (ctx, next) {
-
     /**
      * Params data.
      */

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -166,7 +166,7 @@ Object.assign(Parameters.prototype, {
    * @api private
    */
 
-  _fetch: function (key) {return this._params[key] },
+  _fetch: function (key) { return this._params[key] },
 
   /**
    * Indicates if the key exists.
@@ -198,7 +198,9 @@ Object.assign(Parameters.prototype, {
 
   _permitObject: function (params, filters) {
     for (var key in filters) {
-      var param, isArrObj, filtersArray = filters[key]
+      var param
+      var isArrObj
+      var filtersArray = filters[key]
       if (_.isArray(filtersArray) && (param = this._fetch(key))) {
         if (_.isArray(param._params) || (isArrObj = Object.keys(param._params).every(function (i) { return !_.isNaN(Number(i)) }))) {
           if (isArrObj) {

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -202,6 +202,9 @@ Object.assign(Parameters.prototype, {
       var isArrObj
       var filtersArray = filters[key]
       if (_.isArray(filtersArray) && (param = this._fetch(key))) {
+        if (Parameters._isPrimitive(param)) {
+          continue
+        }
         if (_.isArray(param._params) || (isArrObj = Object.keys(param._params).every(function (i) { return !_.isNaN(Number(i)) }))) {
           if (isArrObj) {
             params[key] = _.transform(param._params, function (result, value, key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strong-params",
-  "version": "0.7.1",
+  "version": "1.0.0",
   "description": "Rails-style strong parameters for javascript projects. (e.g. Express, Koa)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Rails-style strong parameters for javascript projects. (e.g. Express, Koa)",
   "main": "index.js",
   "scripts": {
-    "test": "standard && mocha --harmony --recursive ./spec"
+    "test": "standard && mocha --recursive ./spec"
   },
   "engines": {
-    "node": ">= 0.11.9"
+    "node": "8"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
   ],
   "author": "ssowonny",
   "contributors": [
+    "simonratner",
     "vellotis"
   ],
   "license": "MIT",
@@ -48,11 +49,11 @@
   },
   "homepage": "https://github.com/ssowonny/strong-params",
   "devDependencies": {
-    "body-parser": "~1.10.2",
-    "express": "~4.11.1",
-    "koa": "^0.10.0",
-    "koa-bodyparser": "^1.0.1",
-    "koa-qs": "^1.0.0",
+    "body-parser": "^1.17.2",
+    "express": "^4.15.3",
+    "koa": "^2.3.0",
+    "koa-bodyparser": "^4.2.0",
+    "koa-qs": "^2.0.0",
     "mocha": "^3.0.2",
     "request": "^2.40.0",
     "should": "^11.1.0",
@@ -61,6 +62,6 @@
   },
   "dependencies": {
     "es6-object-assign": "^1.0.2",
-    "lodash": "^3.0.0"
+    "lodash": "^4.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "request": "^2.40.0",
     "should": "^11.1.0",
     "sinon": "^1.17.5",
-    "standard": "^3.0.0"
+    "standard": "^10.0.2"
   },
   "dependencies": {
     "es6-object-assign": "^1.0.2",

--- a/spec/middlewares/express.spec.js
+++ b/spec/middlewares/express.spec.js
@@ -48,11 +48,9 @@ describe('expressMiddleware', function () {
         done(err)
       })
     })
-
   })
 
   describe('req.parameters.require()', function () {
-
     it('should return a `params` object of the required key', function (done) {
       ctx.app.use(function (req, res, next) {
         res.json(req.parameters.require('p1').all())

--- a/spec/middlewares/koa.spec.js
+++ b/spec/middlewares/koa.spec.js
@@ -30,7 +30,6 @@ describe('koaMiddleware', function () {
   })
 
   describe('req.parameters.all()', function () {
-
     it('should return `all` params', function (done) {
       ctx.app.use(function (ctx, next) {
         ctx.body = ctx.parameters.all()
@@ -42,11 +41,9 @@ describe('koaMiddleware', function () {
         done(err)
       })
     })
-
   })
 
   describe('req.parameters.permit()', function () {
-
     it('should return `permit` selected params', function (done) {
       ctx.app.use(function (ctx, next) {
         ctx.body = ctx.parameters.permit('p1', 'a2').value()
@@ -58,11 +55,9 @@ describe('koaMiddleware', function () {
         done(err)
       })
     })
-
   })
 
   describe('req.parameters.require()', function () {
-
     it('should return a `params` object of the required key', function (done) {
       ctx.app.use(function (ctx, next) {
         ctx.body = ctx.parameters.require('p1').all()
@@ -95,7 +90,5 @@ describe('koaMiddleware', function () {
         done(err)
       })
     })
-
   })
-
 })

--- a/spec/middlewares/koa.spec.js
+++ b/spec/middlewares/koa.spec.js
@@ -15,7 +15,7 @@ describe('koaMiddleware', function () {
     ctx = {}
     ctx.port = 3001
     ctx.url = 'http://localhost:' + ctx.port
-    ctx.app = koa()
+    ctx.app = new koa() // eslint-disable-line new-cap
     qs(ctx.app)
     ctx.app.use(bodyparser())
     ctx.app.use(params.koaMiddleware())
@@ -28,8 +28,8 @@ describe('koaMiddleware', function () {
   describe('req.params.all()', function () {
 
     it('should return `all` params', function (done) {
-      ctx.app.use(function *() {
-        this.body = this.params.all()
+      ctx.app.use(function (ctx, next) {
+        ctx.body = ctx.params.all()
       })
       ctx.server = ctx.app.listen(ctx.port)
 
@@ -44,8 +44,8 @@ describe('koaMiddleware', function () {
   describe('req.params.permit()', function () {
 
     it('should return `permit` selected params', function (done) {
-      ctx.app.use(function *() {
-        this.body = this.params.permit('p1', 'a2').value()
+      ctx.app.use(function (ctx, next) {
+        ctx.body = ctx.params.permit('p1', 'a2').value()
       })
       ctx.server = ctx.app.listen(ctx.port)
 
@@ -60,8 +60,8 @@ describe('koaMiddleware', function () {
   describe('req.params.require()', function () {
 
     it('should return a `params` object of the required key', function (done) {
-      ctx.app.use(function *() {
-        this.body = this.params.require('p1').all()
+      ctx.app.use(function (ctx, next) {
+        ctx.body = ctx.params.require('p1').all()
       })
       ctx.server = ctx.app.listen(ctx.port)
 
@@ -72,16 +72,16 @@ describe('koaMiddleware', function () {
     })
 
     it('should throw an exception if the required key does not exist', function (done) {
-      ctx.app.use(function * (next) {
+      ctx.app.use(async function (ctx, next) {
         try {
-          yield* next
+          await next()
         } catch (err) {
-          this.response.status = 500
-          this.response.body = err.message
+          ctx.response.status = 500
+          ctx.response.body = err.message
         }
       })
-      ctx.app.use(function *() {
-        this.body = this.params.require('xx').all()
+      ctx.app.use(function (ctx, next) {
+        ctx.body = ctx.params.require('xx').all()
       })
       ctx.server = ctx.app.listen(ctx.port)
 

--- a/spec/middlewares/koa.spec.js
+++ b/spec/middlewares/koa.spec.js
@@ -18,6 +18,10 @@ describe('koaMiddleware', function () {
     ctx.app = new koa() // eslint-disable-line new-cap
     qs(ctx.app)
     ctx.app.use(bodyparser())
+    ctx.app.use(function (ctx, next) {
+      ctx.params = { id: 'id' }
+      return next()
+    })
     ctx.app.use(params.koaMiddleware())
   })
 
@@ -25,27 +29,27 @@ describe('koaMiddleware', function () {
     ctx.server.close()
   })
 
-  describe('req.params.all()', function () {
+  describe('req.parameters.all()', function () {
 
     it('should return `all` params', function (done) {
       ctx.app.use(function (ctx, next) {
-        ctx.body = ctx.params.all()
+        ctx.body = ctx.parameters.all()
       })
       ctx.server = ctx.app.listen(ctx.port)
 
       request.post({ url: ctx.url + '/?p1=1&p2=2', form: { a1: 1, a2: 2 } }, function (err, res, body) {
-        should(JSON.parse(body)).eql({ p1: '1', p2: '2', a1: '1', a2: '2' })
+        should(JSON.parse(body)).eql({ p1: '1', p2: '2', a1: '1', a2: '2', id: 'id' })
         done(err)
       })
     })
 
   })
 
-  describe('req.params.permit()', function () {
+  describe('req.parameters.permit()', function () {
 
     it('should return `permit` selected params', function (done) {
       ctx.app.use(function (ctx, next) {
-        ctx.body = ctx.params.permit('p1', 'a2').value()
+        ctx.body = ctx.parameters.permit('p1', 'a2').value()
       })
       ctx.server = ctx.app.listen(ctx.port)
 
@@ -57,11 +61,11 @@ describe('koaMiddleware', function () {
 
   })
 
-  describe('req.params.require()', function () {
+  describe('req.parameters.require()', function () {
 
     it('should return a `params` object of the required key', function (done) {
       ctx.app.use(function (ctx, next) {
-        ctx.body = ctx.params.require('p1').all()
+        ctx.body = ctx.parameters.require('p1').all()
       })
       ctx.server = ctx.app.listen(ctx.port)
 
@@ -81,7 +85,7 @@ describe('koaMiddleware', function () {
         }
       })
       ctx.app.use(function (ctx, next) {
-        ctx.body = ctx.params.require('xx').all()
+        ctx.body = ctx.parameters.require('xx').all()
       })
       ctx.server = ctx.app.listen(ctx.port)
 

--- a/spec/parameters.js
+++ b/spec/parameters.js
@@ -9,9 +9,7 @@ var PRIMITIVE_TYPES = [Boolean, Number, String, function Null () {
 }]
 
 describe('Parameters', function () {
-
   describe('class methods', function () {
-
     describe('_initValue', function () {
       PRIMITIVE_TYPES.forEach(function (Primitive) {
         it('should return primitive for ' + Primitive.name, function () {
@@ -105,7 +103,6 @@ describe('Parameters', function () {
         cb.callCount.should.equal(3)
       }))
     })
-
   })
 
   describe('instance methods', function () {
@@ -131,7 +128,6 @@ describe('Parameters', function () {
   })
 
   describe('operations', function () {
-
     describe('constructing', function () {})
     describe('cloning', function () {})
     describe('whitelisting', function () {
@@ -312,7 +308,5 @@ describe('Parameters', function () {
         })
       })
     })
-
   })
-
 })

--- a/spec/parameters.js
+++ b/spec/parameters.js
@@ -307,6 +307,15 @@ describe('Parameters', function () {
           }
         })
       })
+
+      it('should handle scalar input for object filter', function () {
+        // Prepare
+        var filters = [{'primString': []}]
+        // Test
+        var result = params.permit(filters).value()
+        // Verify
+        result.should.deepEqual({})
+      })
     })
   })
 })


### PR DESCRIPTION
This is a breaking change. Suggest leaving the old koa v1.x-compatible version available on a `koa-v1` branch, for those who cannot upgrade.

Also, fixes a bug when scalar input is passed to a filter expecting an object.