### PR TITLE
Simplify null primitive check

### DIFF
--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -15,7 +15,7 @@ var ParameterMissingError = require('./parameter-missing-error')
  * Constants.
  */
 
-var PRIMITIVE_TYPES = [Boolean, Number, String, function Null () {}]
+var PRIMITIVE_TYPES = [Boolean, Number, String, {name: 'null'}]
 
 /**
  * A class for rails-like strong-parameters.


### PR DESCRIPTION
Replace function call with hash so that minifying the code doesn't break primitive check on `null` attributes.

The reason why this was needed is because during production deploy of project that minifies the code turns `Null()` function into an anonymous lambda.  This update addresses that though it's more of a patch.