### PR TITLE
remove node engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "scripts": {
     "test": "standard && mocha --recursive ./spec"
   },
-  "engines": {
-    "node": "8"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/ssowonny/strong-params.git"


### PR DESCRIPTION
I cannot use this in my current project because I am using node version 12, but this library forces node version to 8.